### PR TITLE
Fix NZBIndex RSS parsing

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -766,9 +766,9 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
         'nzbindex':
             {
                 'name': 'NZBIndex',
-                'searchUrl': 'https://nzbindex.com/search/rss?q={0}&hidespam=1&sort=agedesc&complete=1',
-                'regex': r'<link>https:\/\/nzbindex\.com\/download\/(?P<id>\d+)\/?<\/link>',
-                'downloadUrl': 'https://nzbindex.com/download/{id}/',
+                'searchUrl': 'https://nzbindex.com/rss?q={0}&hidespam=1&sort=agedesc&complete=1',
+                'regex': r'<link>https:\/\/nzbindex\.com\/download\/(?P<id>[0-9a-fA-F-]{36})\.nzb<\/link>',
+                'downloadUrl': 'https://nzbindex.com/download/{id}.nzb',
                 'skip_segment_debug': False
             }
     }

--- a/tests/test_nzbindex_regex.py
+++ b/tests/test_nzbindex_regex.py
@@ -1,0 +1,18 @@
+import re
+
+SAMPLE_XML = """
+<item>
+<link>https://nzbindex.com/download/9ea37891-5706-35a6-a1eb-575ad6725f1d.nzb</link>
+</item>
+"""
+
+REGEX = re.compile(r'<link>https://nzbindex\.com/download/(?P<id>[0-9a-fA-F-]{36})\.nzb</link>')
+
+
+def test_nzbindex_regex():
+    match = REGEX.search(SAMPLE_XML)
+    assert match, "No match for NZBIndex regex"
+    nzb_id = match.group('id')
+    assert nzb_id == '9ea37891-5706-35a6-a1eb-575ad6725f1d'
+    download_url = f"https://nzbindex.com/download/{nzb_id}.nzb"
+    assert download_url == 'https://nzbindex.com/download/9ea37891-5706-35a6-a1eb-575ad6725f1d.nzb'


### PR DESCRIPTION
## Summary
- update NZBIndex RSS URL and regex to match current feed
- adjust download URL for NZBIndex
- add a small test verifying the new regex

## Testing
- `pytest -q`
- `curl -I https://nzbindex.com/rss?q=test | head` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I https://nzbindex.com/download/9ea37891-5706-35a6-a1eb-575ad6725f1d.nzb | head` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6867e19f2a688330b989774c15fc0fc2