### PR TITLE
Fix BinSearch search URL

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -750,8 +750,8 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
         'binsearch':
             {
                 'name': 'BinSearch',
-                'searchUrl': 'https://binsearch.info/?q={0}',
-                'regex': r'href="/details/(?P<id>[^"]+)"',
+                'searchUrl': 'https://binsearch.info/search?q={0}',
+                'regex': r'href="https?://binsearch\.info/details/(?P<id>[^"]+)"',
                 'downloadUrl': 'https://binsearch.info/nzb?{id}=on',
                 'skip_segment_debug': False
             },

--- a/tests/test_binsearch.py
+++ b/tests/test_binsearch.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+from unittest.mock import patch, Mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'src'))
+
+# Provide a minimal distutils.spawn module required by nzblnkconfig
+distutils_module = types.ModuleType('distutils')
+spawn_module = types.ModuleType('distutils.spawn')
+def _find_executable(_):
+    return '/usr/bin/true'
+spawn_module.find_executable = _find_executable
+distutils_module.spawn = spawn_module
+sys.modules.setdefault('distutils', distutils_module)
+sys.modules.setdefault('distutils.spawn', spawn_module)
+
+from nzbmonkey import NZBDownload
+
+
+def test_binsearch_download():
+    sample_html = '<a href="https://binsearch.info/details/ABC123">link</a>'
+
+    search_response = Mock()
+    search_response.text = sample_html
+    search_response.status_code = 200
+
+    nzb_response = Mock()
+    nzb_response.text = 'NZB DATA'
+    nzb_response.status_code = 200
+
+    with patch('nzbmonkey.requests.get', side_effect=[search_response, nzb_response]):
+        downloader = NZBDownload(
+            'https://binsearch.info/search?q={0}',
+            r'href="https?://binsearch\.info/details/(?P<id>[^\"]+)"',
+            'https://binsearch.info/nzb?{id}=on',
+            'test'
+        )
+        success, nzb = downloader.download_nzb()
+        assert success
+        assert nzb == 'NZB DATA'
+        assert downloader.nzb_url == 'https://binsearch.info/nzb?ABC123=on'
+


### PR DESCRIPTION
## Summary
- update BinSearch searchUrl and regex to parse absolute URLs
- add a test ensuring NZB retrieval works with new settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e1832cb883309d3c42aa97a34e36