### PR TITLE
Switch setup.py to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import datetime
 import sys
-from distutils.core import setup
+from setuptools import setup
 
 from version import __version__, __requires__
 
@@ -49,6 +49,6 @@ setup(
     author='',
     author_email='',
     description='',
-    requires=__requires__,
+    install_requires=__requires__,
     **params
 )


### PR DESCRIPTION
## Summary
- switch from `distutils.core` to `setuptools` in `setup.py`
- use `install_requires` for dependency specification

## Testing
- `PYTHONPATH=./src python setup.py build`

------
https://chatgpt.com/codex/tasks/task_e_6867de69c6688330aec7fd06fe0b9e03