### PR TITLE
Fix search regex for binsearch and nzbindex

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -767,7 +767,7 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
             {
                 'name': 'BinSearch',
                 'searchUrl': 'https://binsearch.info/search?q={0}',
-                'regex': r'href="https?://binsearch\.info/details/(?P<id>[^"]+)"',
+                'regex': r'href="https?://(?:www\.)?binsearch\.info/(?:details/|\?action=nzb&id=)(?P<id>[^"&/]+)',
                 'downloadUrl': 'https://binsearch.info/nzb?{id}=on',
                 'skip_segment_debug': False
             },
@@ -783,7 +783,7 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
             {
                 'name': 'NZBIndex',
                 'searchUrl': 'https://nzbindex.com/rss?q={0}&hidespam=1&sort=agedesc&complete=1',
-                'regex': r'<link>https:\/\/nzbindex\.com\/download\/(?P<id>[0-9a-fA-F-]{36})\.nzb<\/link>',
+                'regex': r'<link>https:\/\/nzbindex\.com\/download\/(?P<id>[0-9a-fA-F-]{36})(?:\.nzb)?<\/link>',
                 'downloadUrl': 'https://nzbindex.com/download/{id}.nzb',
                 'skip_segment_debug': False
             }

--- a/tests/test_nzbindex_regex.py
+++ b/tests/test_nzbindex_regex.py
@@ -6,7 +6,7 @@ SAMPLE_XML = """
 </item>
 """
 
-REGEX = re.compile(r'<link>https://nzbindex\.com/download/(?P<id>[0-9a-fA-F-]{36})\.nzb</link>')
+REGEX = re.compile(r'<link>https://nzbindex\.com/download/(?P<id>[0-9a-fA-F-]{36})(?:\.nzb)?</link>')
 
 
 def test_nzbindex_regex():
@@ -16,3 +16,17 @@ def test_nzbindex_regex():
     assert nzb_id == '9ea37891-5706-35a6-a1eb-575ad6725f1d'
     download_url = f"https://nzbindex.com/download/{nzb_id}.nzb"
     assert download_url == 'https://nzbindex.com/download/9ea37891-5706-35a6-a1eb-575ad6725f1d.nzb'
+
+
+def test_nzbindex_regex_without_extension():
+    sample_xml = """
+    <item>
+    <link>https://nzbindex.com/download/11111111-2222-3333-4444-555555555555</link>
+    </item>
+    """
+    match = REGEX.search(sample_xml)
+    assert match, "No match for NZBIndex regex without .nzb"
+    nzb_id = match.group('id')
+    assert nzb_id == '11111111-2222-3333-4444-555555555555'
+    download_url = f"https://nzbindex.com/download/{nzb_id}.nzb"
+    assert download_url == 'https://nzbindex.com/download/11111111-2222-3333-4444-555555555555.nzb'


### PR DESCRIPTION
## Summary
- update BinSearch regex to support new URLs
- allow NZBIndex regex to work without explicit `.nzb`
- extend tests for new patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ee61629883308ef904e70b4760ae