### PR TITLE
Fix search regex for binsearch and nzbindex

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -767,7 +767,7 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
             {
                 'name': 'BinSearch',
                 'searchUrl': 'https://binsearch.info/search?q={0}',
-                'regex': r'href="https?://binsearch\.info/details/(?P<id>[^"]+)"',
+                'regex': r'href="(?:https?://(?:www\.)?binsearch\.info)?/(?:details/|\?action=nzb&id=)(?P<id>[^"&/]+)',
                 'downloadUrl': 'https://binsearch.info/nzb?{id}=on',
                 'skip_segment_debug': False
             },
@@ -783,7 +783,7 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
             {
                 'name': 'NZBIndex',
                 'searchUrl': 'https://nzbindex.com/rss?q={0}&hidespam=1&sort=agedesc&complete=1',
-                'regex': r'<link>https:\/\/nzbindex\.com\/download\/(?P<id>[0-9a-fA-F-]{36})\.nzb<\/link>',
+                'regex': r'<link>https?://nzbindex\.com/download/(?P<id>[0-9a-fA-F-]{36})(?:\.nzb)?</link>',
                 'downloadUrl': 'https://nzbindex.com/download/{id}.nzb',
                 'skip_segment_debug': False
             }

--- a/tests/test_binsearch.py
+++ b/tests/test_binsearch.py
@@ -10,8 +10,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'src
 # Provide a minimal distutils.spawn module required by nzblnkconfig
 distutils_module = types.ModuleType('distutils')
 spawn_module = types.ModuleType('distutils.spawn')
+
 def _find_executable(_):
     return '/usr/bin/true'
+
 spawn_module.find_executable = _find_executable
 distutils_module.spawn = spawn_module
 sys.modules.setdefault('distutils', distutils_module)
@@ -21,7 +23,7 @@ from nzbmonkey import NZBDownload
 
 
 def test_binsearch_download():
-    sample_html = '<a href="https://binsearch.info/details/ABC123">link</a>'
+    sample_html = '<a href="/details/ABC123">link</a>'
 
     search_response = Mock()
     search_response.text = sample_html
@@ -34,12 +36,35 @@ def test_binsearch_download():
     with patch('nzbmonkey.requests.get', side_effect=[search_response, nzb_response]):
         downloader = NZBDownload(
             'https://binsearch.info/search?q={0}',
-            r'href="https?://binsearch\.info/details/(?P<id>[^\"]+)"',
+            r'href="(?:https?://(?:www\.)?binsearch\.info)?/(?:details/|\?action=nzb&id=)(?P<id>[^"&/]+)',
             'https://binsearch.info/nzb?{id}=on',
-            'test'
+            'test',
         )
         success, nzb = downloader.download_nzb()
         assert success
         assert nzb == 'NZB DATA'
         assert downloader.nzb_url == 'https://binsearch.info/nzb?ABC123=on'
 
+
+def test_binsearch_regex_new_style():
+    sample_html = '<a href="/?action=nzb&id=XYZ789">link</a>'
+
+    search_response = Mock()
+    search_response.text = sample_html
+    search_response.status_code = 200
+
+    nzb_response = Mock()
+    nzb_response.text = 'NZB DATA'
+    nzb_response.status_code = 200
+
+    with patch('nzbmonkey.requests.get', side_effect=[search_response, nzb_response]):
+        downloader = NZBDownload(
+            'https://binsearch.info/search?q={0}',
+            r'href="(?:https?://(?:www\.)?binsearch\.info)?/(?:details/|\?action=nzb&id=)(?P<id>[^"&/]+)',
+            'https://binsearch.info/nzb?{id}=on',
+            'test',
+        )
+        success, nzb = downloader.download_nzb()
+        assert success
+        assert nzb == 'NZB DATA'
+        assert downloader.nzb_url == 'https://binsearch.info/nzb?XYZ789=on'

--- a/tests/test_nzbindex_regex.py
+++ b/tests/test_nzbindex_regex.py
@@ -6,7 +6,7 @@ SAMPLE_XML = """
 </item>
 """
 
-REGEX = re.compile(r'<link>https://nzbindex\.com/download/(?P<id>[0-9a-fA-F-]{36})\.nzb</link>')
+REGEX = re.compile(r'<link>https?://nzbindex\.com/download/(?P<id>[0-9a-fA-F-]{36})(?:\.nzb)?</link>')
 
 
 def test_nzbindex_regex():
@@ -16,3 +16,28 @@ def test_nzbindex_regex():
     assert nzb_id == '9ea37891-5706-35a6-a1eb-575ad6725f1d'
     download_url = f"https://nzbindex.com/download/{nzb_id}.nzb"
     assert download_url == 'https://nzbindex.com/download/9ea37891-5706-35a6-a1eb-575ad6725f1d.nzb'
+
+
+def test_nzbindex_regex_without_extension():
+    sample_xml = """
+    <item>
+    <link>https://nzbindex.com/download/11111111-2222-3333-4444-555555555555</link>
+    </item>
+    """
+    match = REGEX.search(sample_xml)
+    assert match, "No match for NZBIndex regex without .nzb"
+    nzb_id = match.group('id')
+    assert nzb_id == '11111111-2222-3333-4444-555555555555'
+    download_url = f"https://nzbindex.com/download/{nzb_id}.nzb"
+    assert download_url == 'https://nzbindex.com/download/11111111-2222-3333-4444-555555555555.nzb'
+
+
+def test_nzbindex_http_links():
+    sample_xml = """
+    <item>
+    <link>http://nzbindex.com/download/22222222-3333-4444-5555-666666666666.nzb</link>
+    </item>
+    """
+    match = REGEX.search(sample_xml)
+    assert match, "No match for NZBIndex regex with http"
+    assert match.group('id') == '22222222-3333-4444-5555-666666666666'


### PR DESCRIPTION
## Summary
- update BinSearch regex to support relative links
- match NZBIndex IDs for http or https links
- adjust tests for new patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ee61629883308ef904e70b4760ae